### PR TITLE
Removes duplicate Content-Length headers in REST response

### DIFF
--- a/src/main/java/org/waarp/gateway/kernel/http/HttpRequestHandler.java
+++ b/src/main/java/org/waarp/gateway/kernel/http/HttpRequestHandler.java
@@ -547,7 +547,6 @@ public abstract class HttpRequestHandler extends SimpleChannelInboundHandler<Htt
         if (request == null) {
             if (buf != null) {
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status, buf);
-                response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             } else {
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status);
             }
@@ -568,7 +567,6 @@ public abstract class HttpRequestHandler extends SimpleChannelInboundHandler<Htt
         // Build the response object.
         if (buf != null) {
             response = new DefaultFullHttpResponse(request.protocolVersion(), status, buf);
-            response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         } else {
             response = new DefaultFullHttpResponse(
                     request.protocolVersion(), status);

--- a/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
+++ b/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
@@ -147,8 +147,6 @@ public class HttpWriteCacheEnable {
         }
         response = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK);
-        response.headers().set(HttpHeaderNames.CONTENT_LENGTH,
-                String.valueOf(size));
 
         String type = mimetypesFileTypeMap.getContentType(filename);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, type);

--- a/src/main/java/org/waarp/gateway/kernel/rest/HttpRestHandler.java
+++ b/src/main/java/org/waarp/gateway/kernel/rest/HttpRestHandler.java
@@ -619,7 +619,6 @@ public abstract class HttpRestHandler extends SimpleChannelInboundHandler<HttpOb
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status);
             } else {
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status, content);
-                response.headers().add(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
             }
             setCookies(response);
             setWillClose(true);
@@ -639,7 +638,6 @@ public abstract class HttpRestHandler extends SimpleChannelInboundHandler<HttpOb
         FullHttpResponse response;
         if (content != null) {
             response = new DefaultFullHttpResponse(request.protocolVersion(), status, content);
-            response.headers().add(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
         } else {
             response = new DefaultFullHttpResponse(request.protocolVersion(), status);
         }


### PR DESCRIPTION
Here, the use of `response.headers().add("Content-Length", ...)` added too many
Content-Length, and some clients rejected responses, as per [rfc7230 section-3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2):

> If a message is received that has multiple Content-Length header
> fields with field-values consisting of the same decimal value [...]
> then the recipient MUST either reject the message as invalid or replace
> the duplicated field-values with a single valid Content-Length field
> containing that decimal value prior to determining the message body
> length or forwarding the message.

`headers.set()` or `HttpUtil.setContentLength()` would have been better,
but hey! `Content-Length` is already set (either elsewhere in the code or
by Netty).

Here is an example response prior to the change:

~~~
$  curl http://127.0.0.1:8088/control -d '{"ISACTIVE":true}' -X PUT -v
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8088 (#0)
> PUT /control HTTP/1.1
> Host: 127.0.0.1:8088
> User-Agent: curl/7.47.1
> Accept: */*
> Content-Length: 17
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 17 out of 17 bytes
< HTTP/1.1 400 Bad Request
< content-length: 337
< content-length: 337
< content-type: application/json
< referer: /control
<
* Connection #0 to host 127.0.0.1 left intact
{"message":"Bad Request","code":400,"detail":"com.fasterxml.jackson.databind.JsonMappingException: Unexpected token (END_OBJECT), expected FIELD_NAME: missing property '@class' that is to contain type id  (for class
org.waarp.openr66.protocol.localhandler.packet.json.JsonPacket)\n at [Source: {\"ISACTIVE\":true}; line: 1, column: 17]"}%
~~~

and after:

~~~
$  curl http://127.0.0.1:8088/control -d '{"ISACTIVE":true}' -X PUT -v
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8088 (#0)
> PUT /control HTTP/1.1
> Host: 127.0.0.1:8088
> User-Agent: curl/7.47.1
> Accept: */*
> Content-Length: 17
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 17 out of 17 bytes
< HTTP/1.1 400 Bad Request
< content-length: 337
< content-type: application/json
< referer: /control
<
* Connection #0 to host 127.0.0.1 left intact
{"message":"Bad Request","code":400,"detail":"com.fasterxml.jackson.databind.JsonMappingException: Unexpected token (END_OBJECT), expected FIELD_NAME: missing property '@class' that is to contain type id  (for class
org.waarp.openr66.protocol.localhandler.packet.json.JsonPacket)\n at [Source: {\"ISACTIVE\":true}; line: 1, column: 17]"}
~~~

(the request is not valid, but it is not the point ;-)