### PR TITLE
Solve issue waarp/WaarpR66#198

### DIFF
--- a/src/main/java/org/waarp/gateway/kernel/http/HttpRequestHandler.java
+++ b/src/main/java/org/waarp/gateway/kernel/http/HttpRequestHandler.java
@@ -547,6 +547,7 @@ public abstract class HttpRequestHandler extends SimpleChannelInboundHandler<Htt
         if (request == null) {
             if (buf != null) {
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status, buf);
+                response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             } else {
                 response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, status);
             }
@@ -567,9 +568,9 @@ public abstract class HttpRequestHandler extends SimpleChannelInboundHandler<Htt
         // Build the response object.
         if (buf != null) {
             response = new DefaultFullHttpResponse(request.protocolVersion(), status, buf);
+            response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
         } else {
-            response = new DefaultFullHttpResponse(
-                    request.protocolVersion(), status);
+            response = new DefaultFullHttpResponse(request.protocolVersion(), status);
         }
         if (keepAlive) {
             response.headers().set(HttpHeaderNames.CONNECTION,

--- a/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
+++ b/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
@@ -146,7 +146,7 @@ public class HttpWriteCacheEnable {
             return;
         }
         response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(size));
 
         String type = mimetypesFileTypeMap.getContentType(filename);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, type);

--- a/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
+++ b/src/main/java/org/waarp/gateway/kernel/http/HttpWriteCacheEnable.java
@@ -145,8 +145,8 @@ public class HttpWriteCacheEnable {
             ctx.writeAndFlush(response);
             return;
         }
-        response = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
-                HttpResponseStatus.OK);
+        response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        response.headers().add(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
 
         String type = mimetypesFileTypeMap.getContentType(filename);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, type);


### PR DESCRIPTION
Commit 1a777 removed Content-Length headers in the http response.
The server was able to open the sockets for the first web admin files but those sockets were not closed which cause the issue.

Reversing commit 1a777 for the http response (HttpRequestHandler and HttpWriteCacheEnable) solve the issue.