### PR TITLE
Set default empty filters in REST response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,5 +276,12 @@
   	    <artifactId>netty-all</artifactId>
   	    <version>4.1.6.Final</version>
   	</dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/waarp/gateway/kernel/rest/RestArgument.java
+++ b/src/main/java/org/waarp/gateway/kernel/rest/RestArgument.java
@@ -665,6 +665,9 @@ public class RestArgument {
      *            the filter used in multi get
      */
     public void addFilter(ObjectNode filter) {
+        if (filter == null) {
+            filter = JsonHandler.createObjectNode();
+        }
         getAnswer().putObject(DATAMODEL.JSON_FILTER.field).setAll(filter);
     }
 

--- a/src/test/java/org/waarp/gateway/kernel/rest/RestArgumentTest.java
+++ b/src/test/java/org/waarp/gateway/kernel/rest/RestArgumentTest.java
@@ -1,0 +1,19 @@
+package org.waarp.gateway.kernel.rest;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+public class RestArgumentTest {
+
+    @Test
+    public void testAddFilterNPE() {
+        RestArgument ra = new RestArgument(null);
+        ra.addFilter(null);
+
+        assertSame("filters should be an empty ObjectNode",
+            new ObjectNode(JsonNodeFactory.instance), ra.getFilter());
+    }
+}


### PR DESCRIPTION
Fixes waarp/WaarpR66#203

The "getAll"-type REST requests (and maybe others as well) require a body, even it it is an empty body object(`{}`). Body is the null and thi causes NPEs in processing the response.

This fix considers that when the body is empty, the user did not want to provide any filter. when then replace the null body with an empty filter object (`{}`).

(it just seems more natural to do `curl http://server/hosts` than `curl http://server/hosts -XGET --data "{}"`)