### PR TITLE
REST request that span several TCP packets had no body

### DIFF
--- a/src/main/java/org/waarp/gateway/kernel/rest/HttpRestHandler.java
+++ b/src/main/java/org/waarp/gateway/kernel/rest/HttpRestHandler.java
@@ -666,10 +666,10 @@ public abstract class HttpRestHandler extends SimpleChannelInboundHandler<HttpOb
             ByteBuf buffer = chunk.content();
             if (cumulativeBody != null) {
                 if (buffer.isReadable()) {
-                    cumulativeBody = Unpooled.wrappedBuffer(cumulativeBody, buffer);
+                    cumulativeBody.writeBytes(buffer);
                 }
             } else {
-                cumulativeBody = buffer;
+                cumulativeBody = Unpooled.buffer().writeBytes(buffer);
             }
         } else {
             try {
@@ -686,6 +686,7 @@ public abstract class HttpRestHandler extends SimpleChannelInboundHandler<HttpOb
         if (chunk instanceof LastHttpContent) {
             if (handler.isBodyJsonDecoded()) {
                 jsonObject = getBodyJsonArgs(cumulativeBody);
+                cumulativeBody.release();
                 cumulativeBody = null;
             }
             response.setFromArgument(arguments);


### PR DESCRIPTION
When the body of the request is too big for a single TCP packet, it is spanned
accross several packets.

For each packet received, HttpRestHandler.bodyChunk() is called. This method
keeps the body parts in a buffer until the last packet is received to eventually
get the full body, decode it, and set the body of the request.

The strategy used for that is by using Unpooled.wrappedBuffer() to proxy each
parts own buffer. However, netty reuses the same buffer for every chunk. As
wrappedBuffer *does not* copy the content of the buffer, the buffer eventually
contains N copies of the last chunk, with N being the number of chunks (causing
JSON decoding errors, and in turn an empty body).

This patch copies the content of the buffer of each chunk in cumulativeBuffer to
avoid this problem.

This is a fix for Waarp/WaarpR66#220 (and maybe Waarp/WaarpR66#215).