### PR TITLE
REST API should inform about JSON parsing errors

### DIFF
--- a/src/main/java/org/waarp/gateway/kernel/rest/DataModelRestMethodHandler.java
+++ b/src/main/java/org/waarp/gateway/kernel/rest/DataModelRestMethodHandler.java
@@ -22,6 +22,7 @@ package org.waarp.gateway.kernel.rest;
 
 import java.nio.charset.UnsupportedCharsetException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -132,10 +133,12 @@ public abstract class DataModelRestMethodHandler<E extends AbstractDbData> exten
         ObjectNode node = null;
         try {
             String json = body.toString(WaarpStringUtils.UTF8);
-            node = JsonHandler.getFromString(json);
+            node = JsonHandler.getFromStringExc(json);
         } catch (UnsupportedCharsetException e) {
             logger.warn("Error", e);
             throw new HttpIncorrectRequestException(e);
+        } catch (JsonProcessingException e) {
+            result.setDetail("ERROR: JSON body cannot be parsed");
         }
         if (node != null) {
             arguments.getBody().setAll(node);


### PR DESCRIPTION
As mentionned in Waarp/WaarpR66#221, when the REST API receives PUT queries with
malformed JSON as a body (for example truncated Json), the API simply responds
with a `200 OK` response, letting the user think that all is OK.

The normal way to handle that should be a `400 Bad Request` response, maybe with
information about the error in the `detail` field of the response.
However, in our effort to have a more conservative approach to versionning (by
following [semver](http://semver.org)), and in an effort not to break existing
APIs, such a change would break compatibility (it changes the REST interface).

In this patch, I propose a backward compatible change for those cases where the
JSON body cannot be decoded :
- The status code of the response remains `200 OK`
- A `detail` key is added at the root of the response object to inform the user
  about the error with the following syntax: `ERROR: [error message]`

This way, all previous integrations that used those endpoints and either ignored
errors or dealt with errors another way will continue to work the same;
and an application that want to check for errors can do so with the detail key
of the response.

The API must eventually be reworked to return the right response status, but as
this is a breaking change, this will be added to a future 4.0.0 version.